### PR TITLE
snap: depend on common libperl modules for basic scriptassist support

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -38,6 +38,8 @@ parts:
     stage-packages:
       - perl-base
       - libperl5.22
+      - libdatetime-perl
+      - libwww-perl
     override-build: |
       last_committed_tag="$(git tag | grep -v dev | tail -n 1)"
       last_released_tag="$(snap info irssi | awk '$1 == "beta:" { print $2 }')"


### PR DESCRIPTION
Other dependencies might needed for specific scripts though.

Fixes #4